### PR TITLE
Fixed displaying only the last line of the Avro

### DIFF
--- a/src/main/java/org/eugene/core/avro/AVROReader.java
+++ b/src/main/java/org/eugene/core/avro/AVROReader.java
@@ -23,10 +23,8 @@ public class AVROReader extends Reader {
             //DataFileReader<GenericRecord> dataFileReader = new DataFileReader<>(new File(path.toString()), datumReader);
             FileReader<GenericRecord> dataFileReader = DataFileReader.openReader(inputFile, datumReader);
             List<GenericRecord> data = new ArrayList<>();
-            GenericRecord record = null;
             while (dataFileReader.hasNext()) {
-                record = dataFileReader.next(record);
-                data.add(record);
+                data.add(dataFileReader.next());
             }
             return data;
         }catch(Exception e){


### PR DESCRIPTION
The way the Avro file was read, was to reuse the same object. This means that you got a list of the same object filled with the last read data from the Avro file. I implemented a simple fix to just create a new object every time.