### PR TITLE
Simplify build process

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,16 @@
           <artifactId>javafx-controls</artifactId>
           <version>11.0.2</version>
         </dependency>
+        <dependency>
+          <groupId>org.openjfx</groupId>
+          <artifactId>javafx-media</artifactId>
+          <version>11</version>
+        </dependency>
+        <dependency>
+          <groupId>org.openjfx</groupId>
+          <artifactId>javafx-graphics</artifactId>
+          <version>11</version>
+        </dependency>
       </dependencies>
       <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,11 @@
       <artifactId>sqlite-jdbc</artifactId>
       <version>3.34.0</version>
     </dependency>
+    <dependency>
+      <groupId>org.openjfx</groupId>
+      <artifactId>javafx-controls</artifactId>
+      <version>11.0.2</version>
+    </dependency>
   </dependencies>
 
   <build>
@@ -113,6 +118,14 @@
             </configuration>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.openjfx</groupId>
+        <artifactId>javafx-maven-plugin</artifactId>
+        <version>0.0.3</version>
+        <configuration>
+          <mainClass>org.eugene.FXApplication</mainClass>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,35 @@
   <!-- FIXME change it to the project's website -->
   <url>http://www.example.com</url>
 
+  <profiles>
+    <profile>
+      <id>j11</id>
+      <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+      </properties>
+      <dependencies>
+        <dependency>
+          <groupId>org.openjfx</groupId>
+          <artifactId>javafx-controls</artifactId>
+          <version>11.0.2</version>
+        </dependency>
+      </dependencies>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-maven-plugin</artifactId>
+            <version>0.0.3</version>
+            <configuration>
+              <mainClass>org.eugene.FXApplication</mainClass>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
@@ -70,11 +99,6 @@
       <artifactId>sqlite-jdbc</artifactId>
       <version>3.34.0</version>
     </dependency>
-    <dependency>
-      <groupId>org.openjfx</groupId>
-      <artifactId>javafx-controls</artifactId>
-      <version>11.0.2</version>
-    </dependency>
   </dependencies>
 
   <build>
@@ -119,14 +143,7 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.openjfx</groupId>
-        <artifactId>javafx-maven-plugin</artifactId>
-        <version>0.0.3</version>
-        <configuration>
-          <mainClass>org.eugene.FXApplication</mainClass>
-        </configuration>
-      </plugin>
+
     </plugins>
   </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,6 @@
           </execution>
         </executions>
       </plugin>
-
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
Hello, i added a profile for java 11 users (it may be work with earlier versions, but not earlier than 1.8, i have not tested this yet)
with this profile its easier to build project for newcomers, so that they don't need to add java fx manually, or install something with apt and so on.
I tested this on windows 10 with java 13.0.2
on cent os 7 with java 11.0.11 with vendor Red Hat, Inc. (jdk from their repo)
on mac os 10.13 high sierra 64 bit with java openjdk 15.0.2 (installed with maven after executing brew install maven)
everything worked without adding or installing java fx manually
to build this you need to specify profile:
mvn -Pj11 package
if you not specify the profile, everything will work as it worked before the changes, so i think this changes should break anything that is already exists and working.
Feel free to leave comments if i should add something to this, or decline pull request if you think that this changes is redundant.


